### PR TITLE
Avoid using Function constructor which violates Strict CSP

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,8 @@
 	"root": true,
 
 	"extends": "@ljharb",
+	
+	"parser": "@babel/eslint-parser",
 
 	"rules": {
 		"no-new-func": 1,

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var getGeneratorFunc = function () { // eslint-disable-line consistent-return
 		return false;
 	}
 	try {
-		return Function('return function*() {}')();
+		return (function*() {});
 	} catch (e) {
 	}
 };

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"has-tostringtag": "^1.0.0"
 	},
 	"devDependencies": {
+		"@babel/eslint-parser": "^7.17.0",
 		"@ljharb/eslint-config": "^20.1.0",
 		"aud": "^1.1.5",
 		"auto-changelog": "^2.3.0",


### PR DESCRIPTION
As mentioned in [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/GeneratorFunction), it's not required to use `Function` constructor to get reference of GeneratorFunction.

```
Function('return function*() {}')(); // returns ƒ* () {}
(function*(){}); // returns ƒ* () {}
```

This change will unblock sites to not use CSP `script-src 'unsafe-eval'` which was required when `Function` constructor was being used (since it act as an `eval`).

This a follow up to #41