### PR TITLE
Fix import issue for generator-function

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,9 @@ var fnToStr = callBound('Function.prototype.toString');
 
 var getGeneratorFunction = require('generator-function');
 
+// Hack to fix import, see https://github.com/inspect-js/is-generator-function/issues/45
+if (typeof getGeneratorFunction === 'object' && typeof getGeneratorFunction.default === 'function') getGeneratorFunction = getGeneratorFunction.default
+
 /** @type {import('.')} */
 module.exports = function isGeneratorFunction(fn) {
 	if (typeof fn !== 'function') {


### PR DESCRIPTION
This PR re-adds the "hack" to import the `default` export from `require(generator-function)`, to avoid the apparent "breaking change" from 1.1.0 to 1.1.1, as reported in #46 and #45.



Resolves #46